### PR TITLE
docs(repo): add default pull request template for the creation of the pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Pull request type
+- :heavy_check_mark: Feature
+- :x: Fix
+- :x: Build
+- :x: Refactoring
+- :x: Documentation
+- :x: Blog
+
+## What is the current behavior ?
+issue number: #
+
+## What is the new behavior ?
+- Changelog
+- Changelog
+- Changelog
+
+## Fixed issues
+close #


### PR DESCRIPTION

## Pull request type
- :x: Feature
- :x: Fix
- :x: Build
- :x: Refactoring
- :heavy_check_mark: Documentation
- :x: Blog

## What is the current behavior ?
issue number: #3

## What is the new behavior ?
- Add a default pull request template 

## Fixed issues
close #3
