### PR TITLE
docs(repo): add repository section in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/error_report.md
+++ b/.github/ISSUE_TEMPLATE/error_report.md
@@ -11,6 +11,7 @@ assignees: ChaosDynamix
 
 ### Affected section(s)
 - :x: Documentation
+- :x: Repository
 - :heavy_check_mark: Package
 
 ### Description

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,6 +11,7 @@ assignees: ChaosDynamix
 
 ### Relevant section(s)
 - :x: Documentation
+- :x: Repository
 - :heavy_check_mark: Package
 
 ### Description


### PR DESCRIPTION
## Pull request type
- :x: Feature
- :x: Fix
- :x: Build
- :x: Refactoring
- :heavy_check_mark: Documentation
- :x: Blog

## What is the current behavior ?
issue number: #8

## What is the new behavior ?
Add the repository section in the selection list for the affected/relevant sections in the issue templates.

## Fixed issues
close #8
