### PR TITLE
fix(repo): clarify setions selection list for the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/error_report.md
+++ b/.github/ISSUE_TEMPLATE/error_report.md
@@ -10,9 +10,9 @@ assignees: ChaosDynamix
 # Error report
 
 ### Affected section(s)
-- :x: Documentation
+- :heavy_check_mark: Build system
+- :x: Website
 - :x: Repository
-- :heavy_check_mark: Package
 
 ### Description
 A clear and concise description of the problem...

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,9 +10,9 @@ assignees: ChaosDynamix
 # Feature request
 
 ### Relevant section(s)
-- :x: Documentation
+- :heavy_check_mark: Build system
+- :x: Website
 - :x: Repository
-- :heavy_check_mark: Package
 
 ### Description
 A clear and concise description of the problem or missing documentation and/or capability...


### PR DESCRIPTION
## Pull request type
- :x: Feature
- :heavy_check_mark: Fix
- :x: Build
- :x: Refactoring
- :x: Documentation
- :x: Blog

## What is the current behavior ?
issue number: #11

## What is the new behavior ?
Replace the sections selection list for the issue templates so it is
easier to target the sections of the project affected or relevant for an issue.

New sections are :
- Build system
- Website
- Repository

## Fixed issues
close #11
