### PR TITLE
docs(repo): rename error issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Error report
+name: Bug report
 about: Report a error/bug in the project.
 title: ''
 labels: ''
@@ -7,7 +7,7 @@ assignees: ChaosDynamix
 
 ---
 
-# Error report
+# Bug report
 
 ### Affected section(s)
 - :heavy_check_mark: Build system
@@ -17,7 +17,7 @@ assignees: ChaosDynamix
 ### Description
 A clear and concise description of the problem...
 
-## Exception or error
+## Exception or error message
 ```
 paste the message here...
 ```


### PR DESCRIPTION
## Pull request type
- :x: Feature
- :x: Fix
- :x: Build
- :x: Refactoring
- :heavy_check_mark: Documentation
- :x: Blog

## What is the current behavior ?
issue number: #21

## What is the new behavior ?
- Rename the `error_report.md` to `bug_report.md`
- Rename error to bug in `bug_report.md` 

## Fixed issues
close #21
